### PR TITLE
BCA Changed to BUAN

### DIFF
--- a/lib/domains/bw/bca.txt
+++ b/lib/domains/bw/bca.txt
@@ -1,1 +1,0 @@
-Botswana College of Agriculture

--- a/lib/domains/bw/buan.txt
+++ b/lib/domains/bw/buan.txt
@@ -1,0 +1,1 @@
+Botswana University of Agriculture and Natural Resources


### PR DESCRIPTION
BUAN transformed from the then Botswana College of Agriculture in 2014 to become a fully-fledged university and operate as an independent entity as it was initially an associate institute of the University of Botswana.

The new university now has its own governing and operational structures such as the Senate, Chancellor and Vice Chancellor as well as academic and support staff.